### PR TITLE
Fix nested input handling for grid and CSV writer

### DIFF
--- a/csv_writer.py
+++ b/csv_writer.py
@@ -38,9 +38,11 @@ class CSVWriter(mosaik_api.Simulator):
             # Flatten into one row per time
             row = [time]
             for eid, data in inputs.items():
-                # assumes one value
-                val = list(data.values())[0]
-                row.append(val)
+                # extract numeric value from nested mapping
+                if data:
+                    attr_map = next(iter(data.values()))
+                    val = next(iter(attr_map.values()))
+                    row.append(val)
             if not self.header_written:
                 header = ["time"] + list(inputs.keys())
                 self.writer.writerow(header)

--- a/grid.py
+++ b/grid.py
@@ -38,12 +38,14 @@ class PandapowerSim(mosaik_api.Simulator):
         return entities
 
     def step(self, time, inputs, max_advance=None):
-        for eid, data in inputs.items():
-            if "p_mw" in data:
-                bus = self.entities[eid]["bus"]
-                self.net.load.loc[self.net.load.bus == bus, "p_mw"] = list(
-                    data["p_mw"].values()
-                )[0]
+        for eid, sources in inputs.items():
+            if sources:
+                attr_map = next(iter(sources.values()))
+                if "p_mw" in attr_map:
+                    bus = self.entities[eid]["bus"]
+                    self.net.load.loc[
+                        self.net.load.bus == bus, "p_mw"
+                    ] = attr_map["p_mw"]
         pp.runpp(self.net)
         self.time += self.time_resolution
         return self.time


### PR DESCRIPTION
## Summary
- parse nested input dicts in `PandapowerSim.step`
- extract numeric values in `CSVWriter.step`

## Testing
- `python -m py_compile grid.py random_sim.py csv_writer.py scenario.py`
- `python scenario.py` *(fails: No module named 'pkg_resources')*

------
https://chatgpt.com/codex/tasks/task_e_684ffc9fd5548332882bce30950a2506