### PR TITLE
Fix scenario and simulators for mosaik demo

### DIFF
--- a/csv_writer.py
+++ b/csv_writer.py
@@ -9,7 +9,8 @@ META = {
         "CSVWriter": {
             "public": True,
             "params": ["output_file"],
-            "attrs": [],  # no internal state to expose
+            "attrs": ["vm_pu"],
+            "requires": ["vm_pu"],
         },
     },
 }
@@ -24,7 +25,7 @@ class CSVWriter(mosaik_api.Simulator):
         self.time_resolution = None
 
     def init(self, sid, time_resolution=60, output_file="results.csv", **kwargs):
-        self.time_resolution = time_resolution
+        self.time_resolution = int(time_resolution)
         self.file = open(output_file, "w", newline="")
         self.writer = csv.writer(self.file)
         return self.meta

--- a/grid.py
+++ b/grid.py
@@ -26,7 +26,7 @@ class PandapowerSim(mosaik_api.Simulator):
         self.net = nw.mv_oberrhein(scenario="load")
 
     def init(self, sid, time_resolution=60, **kwargs):
-        self.time_resolution = time_resolution
+        self.time_resolution = int(time_resolution)
         return self.meta
 
     def create(self, num, model):

--- a/random_sim.py
+++ b/random_sim.py
@@ -24,7 +24,7 @@ class RandomSim(mosaik_api.Simulator):
         self.time_resolution = None
 
     def init(self, sid, time_resolution=60, **kwargs):
-        self.time_resolution = time_resolution
+        self.time_resolution = int(time_resolution)
         return self.meta
 
     def create(self, num, model, dist="uniform", low=0, high=1):
@@ -36,7 +36,7 @@ class RandomSim(mosaik_api.Simulator):
         return entities
 
     def step(self, time, inputs, max_advance=None):
-        return time + self.time_resolution
+        return int(time + self.time_resolution)
 
     def get_data(self, outputs):
         data = {}

--- a/scenario.py
+++ b/scenario.py
@@ -26,6 +26,9 @@ def main():
         "CSVWriter", step_size=STEP_SIZE, output_file="results.csv"
     )
 
+    # Create a single CSV writer entity
+    writer = csv_writer.CSVWriter.create(1)[0]
+
     # Create grid entities (e.g., 5 buses)
     grid_entities = grid_sim.OberrheinGrid.create(5)
 
@@ -44,7 +47,7 @@ def main():
 
     # Connect grid outputs to CSV logger
     for grid in grid_entities:
-        world.connect(grid, csv_writer, "vm_pu")
+        world.connect(grid, writer, "vm_pu")
 
     # Run the simulation
     world.run(until=END)


### PR DESCRIPTION
## Summary
- connect simulation entities to the CSVWriter correctly
- make CSVWriter expect `vm_pu` input
- ensure all simulators return Python `int` step times

## Testing
- `python scenario.py > /tmp/run.log & sleep 2; pkill -f scenario.py; tail -n 20 /tmp/run.log`

------
https://chatgpt.com/codex/tasks/task_e_6850044aafb083328c4714d7bba6c2cc