### PR TITLE
Update scenario to use households and hdf5

### DIFF
--- a/scenario.py
+++ b/scenario.py
@@ -1,25 +1,56 @@
 import mosaik
 
+
 SIM_CONFIG = {
     "GridSim": {
-        "python": "grid:PandapowerSim",
+        "python": "mosaik_pandapower.simulator:Pandapower",
+    },
+    "HouseholdSim": {
+        "python": "mosaik_householdsim.mosaik:HouseholdSim",
+    },
+    "HDF5": {
+        "cmd": "mosaik-hdf5 %(addr)s",
     },
 }
 
+
 END = 3600  # 1 hour simulation
-STEP_SIZE = 60  # 1-minute time steps
+STEP_SIZE = 900  # 15-minute time steps
 
 
 def main():
     world = mosaik.World(SIM_CONFIG)
 
-    # Start simulator
     grid_sim = world.start("GridSim", step_size=STEP_SIZE)
+    hh_sim = world.start("HouseholdSim", step_size=STEP_SIZE)
+    hdf5 = world.start("HDF5", step_size=STEP_SIZE)
 
-    # Create grid entities (e.g., 5 buses)
-    grid_sim.OberrheinGrid.create(5)
+    # Load grid description
+    grid = grid_sim.Grid.create(1, gridfile="grid.json")[0]
 
-    # Run the simulation
+    # Create residential load entities
+    houses_parent = hh_sim.ResidentialLoads.create(
+        1,
+        sim_start="2025-01-01 00:00:00",
+        profile_file="load_profiles.data",
+        grid_name="Oberrhein",
+    )[0]
+    houses = houses_parent.children
+
+    # Connect houses to their buses
+    node_ids = world.get_data(houses, "node_id")
+    buses = {bus.eid: bus for bus in grid.children if bus.type == "Bus"}
+    for house in houses:
+        node_id = node_ids[house]["node_id"]
+        bus = buses.get(node_id)
+        if bus:
+            world.connect(house, bus, ("P_out", "p_mw"))
+
+    # Store bus results in HDF5
+    db = hdf5.Database.create(1, filename="results.hdf5")[0]
+    for bus in buses.values():
+        world.connect(bus, db, "vm_pu")
+
     world.run(until=END)
 
 


### PR DESCRIPTION
## Summary
- configure simulators for mosaik-pandapower, householdsim and HDF5
- load the grid and residential profiles
- connect households to buses and log bus voltages

## Testing
- `python -m py_compile scenario.py`


------
https://chatgpt.com/codex/tasks/task_e_68515d41a6b08332b9cf9288b340384f