### PR TITLE
Clarify output file and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mosaik Demo
 
 This repository contains a simple Mosaik setup with a grid simulator,
-a random data generator, and a CSV logger. Use the following steps to
+a random data generator, and an HDF5 logger. Use the following steps to
 run the example scenario.
 
 ## 1. Install dependencies
@@ -39,6 +39,7 @@ python scenario.py
 
 ## 5. Inspect results
 
-After the run finishes the results are written to `results.hdf5`. This
-file contains the collected outputs of the grid simulation and can be
-analysed with your preferred tools.
+After the run finishes the results are written to `results.hdf5`. No
+`results.csv` file is generated. The HDF5 file contains the collected
+outputs of the grid simulation and can be analysed with your preferred
+tools.


### PR DESCRIPTION
## Summary
- remove unused `results.csv`
- note that an HDF5 logger is used
- explain that `results.hdf5` is the only results file
- keep the dependency installation instruction

## Testing
- `python -m py_compile generate_grid.py grid.py scenario.py`

------
https://chatgpt.com/codex/tasks/task_e_6851929955308332bd58cdf45d1d8787