### PR TITLE
Pin numpy below 2 for pandapower

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 mosaik==3.5.0
 mosaik-api==3.0.3
 pandas>=1.3.0
+numpy<2.0
 pandapower==2.13.1
 mosaik-pandapower
 mosaik-householdsim


### PR DESCRIPTION
## Summary
- pin numpy to stay below 2.0 so pandapower imports `Inf` constant

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import pandapower
print('pandapower version', pandapower.__version__)
from numpy import Inf
print('Inf constant is', Inf)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6851a5451efc8332b7a8f99313f31509