### PR TITLE
Fix pandapower adapter version pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ mosaik-api==3.0.3
 pandas>=1.3.0
 numpy<2.0
 pandapower==2.13.1
-mosaik-pandapower
+mosaik-pandapower==0.2.2
 mosaik-householdsim
 mosaik-hdf5


### PR DESCRIPTION
## Summary
- pin `mosaik-pandapower` to 0.2.2 in the requirements to avoid conflicts with `mosaik-pandapower-2`

## Testing
- `python generate_grid.py`
- `pip install -r requirements.txt`
- `python scenario.py`

------
https://chatgpt.com/codex/tasks/task_e_685280b61b6c83329e284efa5c77f97f